### PR TITLE
feat(docker-support): add docker support and update instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 
 target/
 dbt_modules/
+dbt_packages/
 logs/
 **/.DS_Store
+.user.yml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jaffle_shop_with_fal
+# Testing dbt + fal: `jaffle_shop_with_fal`
 
 <p align="center">
   <a href="https://getdbt.slack.com/archives/C02V8QW3Q4Q">
@@ -20,47 +20,43 @@ The [fal](https://github.com/fal-ai/fal) + [dbt-fal](https://github.com/fal-ai/f
 
 With this combo, you won't have to leave your dbt project and still add more capabilities to your stack.
 
+### Pre-requisites
+
+- [Install Docker](https://docs.docker.com/get-docker/). Check if the installation is ok with `docker --version`.
+  - **Note:** if you're on Linux, check the [post-install steps](https://docs.docker.com/engine/install/linux-postinstall/).
+- Make sure `dbt-core` is installed. Verify with `dbt --version`. If not, see [DBT Installation](https://docs.getdbt.com/docs/get-started/installation) for instructions.
+- **[Optional but recommended]** [Install `pyenv`](https://github.com/pyenv/pyenv) or an alternative to leverage isolated Python environments.
+
 ### Installing Instructions:
 
-1. Install `fal` and `dbt-fal`
+1. Install `fal`, `dbt-fal` and other dependencies
 
 ```
-$ pip install fal dbt-fal[postgres]
-# Add your favorite adapter here
+$ pip install -r requirements.txt
 ```
 
-2. Specify the `fal` adapter in your `profiles.yml`:
+2. Create the database
 
-```yaml
-jaffle_shop:
-  target: fal_dev
-  outputs:
-    pg_dev:
-      type: postgres
-      host: localhost
-      port: 5432
-      user: pguser
-      password: pass
-      dbname: test
-      schema: public
-      threads: 4
+To set up the environment using `docker-compose`, follow these steps:
 
-    fal_dev:
-      type: fal
-      db_profile: pg_dev # This points to the adapter to use for SQL-related tasks
+ - Install [`docker`](https://docs.docker.com/get-docker) and [`docker-compose`](https://docs.docker.com/compose/install) on your machine. 
+ - Navigate to the directory containing the docker-compose.yml file.
+ - Run `docker-compose up` to start the database.
+   - Note: If you want to run the container in background use `docker-compose up -d`
+
+```
+$ docker-compose up
 ```
 
-With this profiles configuration, fal will run all the Python models and will leave the SQL models to the `db_profile`.
+As a **bonus**, the stack includes adminer that can be used to browse the database and interact with the results. You can access it at `http://localhost:58080`.
 
-3. ~~Install the data science libraries to run the clustering script.~~
-
-We now use `fal_project.yml` to create isolated environments for Python models.
-
-4. Seed the test data
+3. Seed the test data
 
 ```
 $ dbt seed
 ```
+
+**Note:** As aforementioned, fal works with any dbt adapter. Although this example is ready for Postgres, feel free to play around with it and switch to your favorite dbt-supported database.
 
 ### Running Instructions:
 

--- a/README.md
+++ b/README.md
@@ -29,32 +29,37 @@ With this combo, you won't have to leave your dbt project and still add more cap
 
 ### Installing Instructions:
 
-1. Install `fal`, `dbt-fal` and other dependencies
+1. Install dependencies
 
-```
-$ pip install -r requirements.txt
-```
+    ```
+    $ pip install -r requirements.txt
+    ```
 
 2. Create the database
 
-To set up the environment using `docker-compose`, follow these steps:
+    #### Option 1: Docker
 
- - Install [`docker`](https://docs.docker.com/get-docker) and [`docker-compose`](https://docs.docker.com/compose/install) on your machine. 
- - Navigate to the directory containing the docker-compose.yml file.
- - Run `docker-compose up` to start the database.
-   - Note: If you want to run the container in background use `docker-compose up -d`
+    We provide a ready-to-use environment. To set up the environment using `docker-compose`, follow these steps:
 
-```
-$ docker-compose up
-```
+    - Install [`docker`](https://docs.docker.com/get-docker) and [`docker-compose`](https://docs.docker.com/compose/install) on your machine.
+    - Run `docker-compose up` to start the database.
+      - Note: If you want to run the container in background use `docker-compose up -d`.
 
-As a **bonus**, the stack includes adminer that can be used to browse the database and interact with the results. You can access it at `http://localhost:58080`.
+    ```
+    $ docker-compose up
+    ```
+
+    **Note:** the stack includes adminer, an admin interface for easy database browsing. You can access it at `http://localhost:58080`.
+
+    #### Option 2: Local database
+
+    If you want to bring your own database, make sure to update the connection settings on `profiles.yml` to match your database.
 
 3. Seed the test data
 
-```
-$ dbt seed
-```
+    ```
+    $ dbt seed
+    ```
 
 **Note:** As aforementioned, fal works with any dbt adapter. Although this example is ready for Postgres, feel free to play around with it and switch to your favorite dbt-supported database.
 
@@ -62,19 +67,19 @@ $ dbt seed
 
 1. Run your dbt models
 
-```bash
-$ dbt run
-## Runs the SQL models on the datawarehouse and Python models locally with fal
-```
+    ```bash
+    $ dbt run
+    ## Runs the SQL models on the datawarehouse and Python models locally with fal
+    ```
 
 2. Run `fal flow run` to execute the full graph including fal Python scripts, that is the `fal_scripts/notify.py` script.
 You can use the dbt [graph selectors](https://docs.getdbt.com/reference/node-selection/graph-operators) and [much more](https://docs.fal.ai/).
 With `fal flow run`, you will not have to run `dbt run` since fal handles the full execution.
 
-```bash
-$ fal flow run
-## Runs dbt run and the associated scripts, in this case a Slack notification is triggered
-```
+    ```bash
+    $ fal flow run
+    ## Runs dbt run and the associated scripts, in this case a Slack notification is triggered
+    ```
 
 ### Curious to learn more?
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:14
+    restart: always
+    environment:
+      - POSTGRES_USER=pguser
+      - POSTGRES_PASSWORD=pgsecret
+      - POSTGRES_DB=jaffle_shop
+    ports:
+      - '50432:5432'
+    volumes:
+      - db:/var/lib/postgresql/data
+  adminer:
+    image: adminer
+    restart: always
+    environment:
+      - ADMINER_DESIGN=pepa-linha-dark
+    ports:
+      - 58080:8080
+
+volumes:
+  db:
+    driver: local

--- a/profiles.yml
+++ b/profiles.yml
@@ -1,0 +1,16 @@
+jaffle_shop:
+  target: fal_dev
+  outputs:
+    pg_dev:
+      type: postgres
+      host: localhost
+      port: 50432
+      user: pguser
+      password: pgsecret
+      dbname: jaffle_shop
+      schema: public
+      threads: 4
+
+    fal_dev:
+      type: fal
+      db_profile: pg_dev # This points to the adapter to use for SQL-related tasks

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+dbt-fal[postgres]
+dbt-postgres
+fal
+slack_sdk


### PR DESCRIPTION
This PR introduces Docker to the dbt+fal demo project in order to make it easier to get it running and also supported in containezed environments, such as GitHub Codespaces.

#### Summary of the changes:

- added `docker-compose.yml` with a postgres+adminer setup
- added the `profiles.yml` to the repo so one step could be removed from the setup process
- added `requirements.txt` and the `slack_sdk` missing dependency so less steps are required to get it running
- updated the README instructions

#### Stretch goal - Codespaces

- Make it work on Codespaces came up and I gave it a shot. It mostly works out-of-the-box due to the changes above! There's still some Python environment hickups: https://drochetti-effective-invention-75v7rxvp4h46w.github.dev/